### PR TITLE
Address DMD firmware patterns by single index

### DIFF
--- a/mcsim/analysis/odt_patterns.py
+++ b/mcsim/analysis/odt_patterns.py
@@ -12,12 +12,12 @@ def get_odt_spot_locations(nmax: int,
                            fx_max: float = 1.,
                            fy_max: float = 1.) -> np.ndarray:
     """
-    Generate set of spot locations equally spaced in back-pupil plane
+    Generate set of spot locations equally spaced in back-pupil plane. Scale is set by fmax
 
-    :param nmax:
+    :param nmax: maximum number of spots
     :param fmax: maximum radius
     :param fx_max: maximum distance in x-direction
-    :param fy_max: maximum distnace in y-direction
+    :param fy_max: maximum distance in y-direction
     :return centers: ncenters x 2 in order cx x cy
     """
 
@@ -308,9 +308,7 @@ def get_odt_patterns(center_set: Sequence[np.ndarray],
     odt_pattern_data = []
     # loop over patterns
     for ii, centers_now in enumerate(center_set):
-
         drs_now = drs[ii]
-        nr = len(np.unique(drs_now))
 
         if len(centers_now) != len(drs_now):
             raise ValueError("center positions must match size of drs")
@@ -340,7 +338,7 @@ def get_odt_patterns(center_set: Sequence[np.ndarray],
         # record pattern metadata
         odt_pattern_data.append({"type": "odt",
                                  "drs": drs_now.tolist(),
-                                 "nposition_multiplex": nr,
+                                 "nposition_multiplex": len(np.unique(drs_now)),
                                  "offsets": (pupil_rad_mirrors * centers_now).tolist(),
                                  "nangles_multiplex_nominal": len(centers_now),
                                  "spot_frqs_mirrors": frqs_mirrors.tolist(),

--- a/mcsim/expt_ctrl/set_dmd_odt_pattern.py
+++ b/mcsim/expt_ctrl/set_dmd_odt_pattern.py
@@ -69,7 +69,7 @@ if one_pattern:
     centered_pattern[np.sqrt((xx - cref[1] - offset[1])**2 + (yy - cref[0] - offset[0])**2) > rad] = 1
 
     # centered_pattern = np.ones(dmd_size)
-    img_inds, bit_inds = dmd.upload_pattern_sequence(centered_pattern.astype(np.uint8), 105, 0)
+    dmd.upload_pattern_sequence(centered_pattern.astype(np.uint8), 105, 0)
 else:
     # or, many patterns
     n_phis = 10
@@ -100,4 +100,4 @@ else:
     # exp_time_us = 1000000 # 1s
     # exp_time_us = 100000 # 100ms
     exp_time_us = 105
-    img_inds, bit_inds = dmd.upload_pattern_sequence(patterns, exp_time_us, 0)
+    dmd.upload_pattern_sequence(patterns, exp_time_us, 0)


### PR DESCRIPTION
Changed code to address firmware patterns by a single number index. For the DLP6500, these are actually stored in the firmware and addressed using a picture index and a bit index. Each picture has 24 bits. That is an implementation detail that does not need to be exposed to the user, and now it no longer is